### PR TITLE
docs: add code documentation to currency

### DIFF
--- a/src/currency/index.ts
+++ b/src/currency/index.ts
@@ -1,16 +1,20 @@
-interface CurrncyMaskProps {
+interface CurrencyMaskProps {
 	locale: string | string[]
 	currency: string
 	value: number | bigint
 }
 
-interface CurrncyUnmaskProps {
+interface CurrencyUnmaskProps {
 	locale: string | string[]
 	currency: string
 	value: string
 }
 
-export const mask = ({ locale, currency, value }: CurrncyMaskProps): string => {
+export const mask = ({
+	locale,
+	currency,
+	value,
+}: CurrencyMaskProps): string => {
 	const { format } = new Intl.NumberFormat(`${locale}`, {
 		style: 'currency',
 		currency,
@@ -19,7 +23,7 @@ export const mask = ({ locale, currency, value }: CurrncyMaskProps): string => {
 	return format(value)
 }
 
-export const unmask = ({ locale, currency, value }: CurrncyUnmaskProps) => {
+export const unmask = ({ locale, currency, value }: CurrencyUnmaskProps) => {
 	const formatter = new Intl.NumberFormat(locale, {
 		style: 'currency',
 		currency,

--- a/src/currency/index.ts
+++ b/src/currency/index.ts
@@ -1,15 +1,22 @@
 interface CurrencyMaskProps {
+	/** Locale used to format. Refer to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument MDN Docs} for futher explanation.*/
 	locale: string | string[]
+	/** The currency to use in currency formatting. Possible values are the `ISO 4217` currency codes. Refer to {@link https://wikipedia.org/wiki/ISO_4217 Wikipedia} to see all codes.*/
 	currency: string
+	/** The amount to be formatted. */
 	value: number | bigint
 }
 
 interface CurrencyUnmaskProps {
+	/** The locale used to format the amount. */
 	locale: string | string[]
+	/** The currency used to format the amount. */
 	currency: string
+	/** The formatted amount. */
 	value: string
 }
 
+/** Formats a given amount by the `locale` and `currency` provided.*/
 export const mask = ({
 	locale,
 	currency,
@@ -23,6 +30,7 @@ export const mask = ({
 	return format(value)
 }
 
+/** Given a `formatted amount`, `locale` and `currency`, returns the numeric value it corresponds to.*/
 export const unmask = ({ locale, currency, value }: CurrencyUnmaskProps) => {
 	const formatter = new Intl.NumberFormat(locale, {
 		style: 'currency',


### PR DESCRIPTION
This PR fixes `currency` misspelling on interfaces names. It also adds code documentation to improve DX.

I could do the same for masker, if you like it.

Example screenshot:
![image](https://github.com/brunobertolini/remask/assets/26507864/a81cd4ee-e023-4c47-a4f2-b16080db56e3)
